### PR TITLE
features: Firefox mask fix, ImageBox class, basic arcs in line

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "react-redux": "^7.2.6",
     "redux": "^4.1.2",
     "transformation-matrix": "^2.10.0",
-    "ts-is-present": "^1.2.2"
+    "ts-is-present": "^1.2.2",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
@@ -70,6 +71,7 @@
     "@types/lodash-es": "^4.17.6",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^18.0.11",
+    "@types/uuid": "^9.0.1",
     "autoprefixer": "^10.4.2",
     "babel-jest": "^29.5.0",
     "babel-loader": "^8.2.3",

--- a/packages/d3-packages/Circle.ts
+++ b/packages/d3-packages/Circle.ts
@@ -76,7 +76,7 @@ export class Circle extends Shape {
       .attr('stroke-width', this.borderWidth)
       .attr('stroke', this.borderColor)
       .attr('fill', this.color)
-      .attr('mask', `url(#${maskIdentifier})`)
+      .attr('mask', (render_masks.length > 0 ) ? `url(#${maskIdentifier})` : '')
       .attr('opacity', this.opacity());
     super.render(svg, render_masks);
   }

--- a/packages/d3-packages/Constants.ts
+++ b/packages/d3-packages/Constants.ts
@@ -8,8 +8,9 @@ export const DEFAULT_TEXT_COLOR: string = "rgb(0, 0, 0)"
 
 export const DEFAULT_LINE_COLOR: string = "rgb(0, 0, 0)"
 
+//these can be adjusted - the settings that I saw on my machine
 export const SCREEN_WIDTH: number = 1500
-export const SCREEN_HEIGHT:number = 1500 //these can be adjusted - the settings that I saw on my machine
+export const SCREEN_HEIGHT:number = 1500 
 
 /**
  * GRAPH RELATED CONSTANTS

--- a/packages/d3-packages/Ellipse.ts
+++ b/packages/d3-packages/Ellipse.ts
@@ -77,7 +77,7 @@ export class Ellipse extends Shape {
       .attr('stroke-width', this.borderWidth())
       .attr('stroke', this.borderColor())
       .attr('fill', this.color())
-      .attr('mask', `url(#${maskIdentifier})`)
+      .attr('mask', (render_masks.length > 0) ? `url(#${maskIdentifier})` : '')
       .attr('opacity', this.opacity());
     super.render(svg, render_masks);
   }

--- a/packages/d3-packages/ImageBox.ts
+++ b/packages/d3-packages/ImageBox.ts
@@ -1,0 +1,63 @@
+import * as d3 from 'd3';
+//import {} from './Constants';
+import { VisualObject } from './VisualObject';
+import { BoundingBox, Coords, toFunc } from './Utility';
+
+export interface ImageBoxProps {
+  coords?: Coords | (() => Coords);
+  url?: string | (() => string);
+  width: number | (() => number);
+  height: number | (() => number);
+}
+
+export class ImageBox extends VisualObject {
+  url: () => string;
+  width: () => number;
+  height: () => number;
+
+  /**
+   * Fetches an image from a URL and displays it within a box
+   */
+  constructor(props: ImageBoxProps) {
+    super(props.coords);
+    this.url = toFunc('', props.url);
+    this.width = toFunc(100, props.width);
+    this.height = toFunc(100, props.height);
+  }
+
+  boundingBox(): BoundingBox {
+    return {
+        top_left: {
+          x: this.center().x - this.width() / 2,
+          y: this.center().y - this.height() / 2
+        },
+        bottom_right: {
+          x: this.center().x + this.width() / 2,
+          y: this.center().y + this.height() / 2
+        }
+      };
+  }
+
+  override render(svg: any, parent_masks: BoundingBox[]) {
+
+    let maskIdentifier: string = '';
+
+    let render_masks: BoundingBox[];
+    if (parent_masks) {
+      render_masks = this.masks.concat(parent_masks);
+    } else {
+      render_masks = this.masks;
+    }
+    maskIdentifier = this.addMaskRender(render_masks, svg);
+
+    d3.select(svg)
+        .append("svg:image")
+        .attr('x', this.center().x - this.width() / 2)
+        .attr('y', this.center().y - this.height() / 2)
+        .attr('width', this.width())
+        .attr('height', this.height())
+        .attr('mask', (render_masks.length > 0) ? `url(#${maskIdentifier})` : '')
+        .attr("xlink:href", `${this.url()}`)
+    super.render(svg);
+  }
+}

--- a/packages/d3-packages/Line.ts
+++ b/packages/d3-packages/Line.ts
@@ -224,7 +224,7 @@ export class Line extends VisualObject {
         // Default sweep to `1` (curve upward on a left-to-right line)
         return `M ${truePoints[0].x} ${truePoints[0].y} 
                 A ${curveSpec.xradius} ${curveSpec.yradius} ${0} ${0} 
-                  ${curveSpec.sweep ? curveSpec.sweep : 1} ${truePoints[1].x} ${truePoints[1].y}`
+                  ${curveSpec.sweep !== undefined ? curveSpec.sweep : 1} ${truePoints[1].x} ${truePoints[1].y}`
       case 'cubic': 
         console.log('Error: cubic curves currently unsupported by Line')
         throw new Error('cubic curves currently unsupported by Line')

--- a/packages/d3-packages/Line.ts
+++ b/packages/d3-packages/Line.ts
@@ -222,6 +222,8 @@ export class Line extends VisualObject {
         // D3 is not currently building the arc as expected, so build the 
         // SVG path string directly. Ignore all but the first two points. 
         // Default sweep to `1` (curve upward on a left-to-right line)
+        // TODO: first 0 is the angle relative to the x axis
+        // TODO: second 0 should be 1 if the arc sweeps > 180 degrees
         return `M ${truePoints[0].x} ${truePoints[0].y} 
                 A ${curveSpec.xradius} ${curveSpec.yradius} ${0} ${0} 
                   ${curveSpec.sweep !== undefined ? curveSpec.sweep : 1} ${truePoints[1].x} ${truePoints[1].y}`

--- a/packages/d3-packages/Polygon.ts
+++ b/packages/d3-packages/Polygon.ts
@@ -46,9 +46,9 @@ export class Polygon extends Shape{
         let maskIdentifier: string = '';
         let render_masks: BoundingBox[];
         if (parent_masks) {
-        render_masks = this.masks.concat(parent_masks);
+          render_masks = this.masks.concat(parent_masks);
         } else {
-        render_masks = this.masks;
+          render_masks = this.masks;
         }
         let truePoints: Coords[] = this.pointsRelative.map((pointFn): Coords => {return {
             x: pointFn().x + this.center().x,
@@ -68,7 +68,7 @@ export class Polygon extends Shape{
             .attr('stroke-width', this.borderWidth)
             .attr('stroke', this.borderColor)
             .attr('fill', this.color)
-            .attr('mask', `url(#${maskIdentifier})`)
+            .attr('mask', (render_masks.length > 0) ? `url(#${maskIdentifier})` : '')
             .attr('opacity', this.opacity()) 
         super.render(svg, render_masks)
     }

--- a/packages/d3-packages/Rectangle.ts
+++ b/packages/d3-packages/Rectangle.ts
@@ -130,7 +130,7 @@ export class Rectangle extends Shape {
       .attr('stroke-width', this.borderWidth())
       .attr('stroke', this.borderColor())
       .attr('fill', this.color())
-      .attr('mask', `url(#${maskIdentifier})`)
+      .attr('mask', (render_masks.length > 0) ? `url(#${maskIdentifier})` : '')
       .attr('opacity', this.opacity());
     super.render(svg, render_masks);
   }

--- a/packages/d3-packages/ScriptViewImports.ts
+++ b/packages/d3-packages/ScriptViewImports.ts
@@ -13,6 +13,7 @@ import { boxUnion } from './Utility';
 import { Hull } from './Hull';
 import { ConjoinedObject } from './ConjoinedObject'
 import { Ellipse } from './Ellipse';
+import { ImageBox } from './ImageBox';
 
 interface scriptViewImport {
   name: string;
@@ -41,7 +42,8 @@ const scriptViewImports: scriptViewImport[] = [
   { name: 'Hull', value: Hull },
   { name: 'ConjoinedObject', value: ConjoinedObject },
   { name: 'boxUnion', value: boxUnion },
-  { name: 'Ellipse', value: Ellipse}
+  { name: 'Ellipse', value: Ellipse},
+  { name: 'ImageBox', value: ImageBox}
 ];
 
 export { scriptViewImports };

--- a/packages/d3-packages/Stage.ts
+++ b/packages/d3-packages/Stage.ts
@@ -16,10 +16,15 @@ export class Stage{
     add(addObject:VisualObject){
         this.Children.push(addObject)
     }
+    
     addAll(addObjects:VisualObject[]){
         addObjects.forEach((o) => {
             this.Children.push(o);
         })
+    }
+
+    remove(removeObject: VisualObject){
+        this.Children = this.Children.filter(c => c !== removeObject)
     }
 
     addMask(bb:BoundingBox){

--- a/packages/d3-packages/Textbox.ts
+++ b/packages/d3-packages/Textbox.ts
@@ -79,7 +79,7 @@ export class TextBox extends VisualObject {
       .attr('text-anchor', 'middle')
       .attr('alignment-baseline', 'central')
       .attr('font-size', this.fontSize)
-      .attr('mask', `url(#${maskIdentifier})`)
+      .attr('mask', (render_masks.length > 0) ? `url(#${maskIdentifier})` : '')
       .attr('fill', this.color)
       .text(this.text);
     super.render(svg);

--- a/packages/d3-packages/Textbox.ts
+++ b/packages/d3-packages/Textbox.ts
@@ -13,12 +13,26 @@ export interface TextBoxProps {
   coords?: Coords | (() => Coords);
   color?: string | (() => string);
   fontSize?: number | (() => number);
+  events?: VisualObjectEventDecl[] | (() => VisualObjectEventDecl[])
+}
+
+/**
+ * Taken from D3's declarations. `d` is typed within D3, but via
+ * a type parameter.
+ */
+export type VisualObjectEventCallback = 
+  (this: SVGTextElement, event: any, d: any) => void
+export interface VisualObjectEventDecl {
+  event: string,
+  callback: VisualObjectEventCallback,
+  options?: any // D3's type decls use `any` here
 }
 
 export class TextBox extends VisualObject {
   text: () => string;
   fontSize: () => number;
   color: () => string;
+  events: () => VisualObjectEventDecl[];
 
   /**
    * Displays given text.
@@ -32,6 +46,7 @@ export class TextBox extends VisualObject {
     this.text = toFunc('', props.text);
     this.fontSize = toFunc(DEFAULT_FONT_SIZE, props.fontSize);
     this.color = toFunc(DEFAULT_TEXT_COLOR, props.color);
+    this.events = toFunc([], props.events)
   }
 
   boundingBox(): BoundingBox {
@@ -72,7 +87,7 @@ export class TextBox extends VisualObject {
     }
     maskIdentifier = this.addMaskRender(render_masks, svg);
 
-    d3.select(svg)
+    const d3Box = d3.select(svg)
       .append('text')
       .attr('x', this.center().x)
       .attr('y', this.center().y)
@@ -82,6 +97,13 @@ export class TextBox extends VisualObject {
       .attr('mask', (render_masks.length > 0) ? `url(#${maskIdentifier})` : '')
       .attr('fill', this.color)
       .text(this.text);
+
+    // Because of how props are lifted to a function, they can
+    // never themselves have function type. Instead, have one 
+    // event prop (object), which is more extensible anyway. 
+    if(this.events()) 
+      this.events().forEach(e => d3Box.on(e.event, e.callback))
+
     super.render(svg);
   }
 }

--- a/packages/d3-packages/Utility.ts
+++ b/packages/d3-packages/Utility.ts
@@ -5,14 +5,16 @@
 
 export function toFunc<T>(defaultValue: T, t?: T | (() => T)): (() => T)  {
     let constOrFunction: T | (() => T) = t ?? defaultValue
-    if (typeof constOrFunction !== "function") {
+    // This will require a typecast below:
+    //if (typeof constOrFunction !== "function") {
+    // This does not:
+    if(!(constOrFunction instanceof Function)) {
         let constVal: T = constOrFunction
         return () => constVal
     } else {
-        // This is a bit wonky because typescript is worried that constOrFunction
-        // is both T and a function. Note that this sort of narrowing will NOT
-        // work in the case of T being a function type itself! It has to be something else
-        return constOrFunction as () => T
+        // Note that this sort of narrowing will NOT work in the case of T 
+        // being a function type itself! It has to be something else.
+        return constOrFunction
     }
 }
 

--- a/packages/d3-packages/test/geometricHelpers.test.ts
+++ b/packages/d3-packages/test/geometricHelpers.test.ts
@@ -1,0 +1,16 @@
+import { svgArcEndpointToCenter } from '../geometricHelpers'
+
+test("svgArcEndpointToCenter: initial test", () => {
+    const input = {
+        x1: 200,y1: 200,rx: 50,ry: 50, phi: 0, 
+        fA: true, fS: true, x2: 300, y2: 200}
+    const output = svgArcEndpointToCenter(input)
+    expect(output.cx).toBe(250)
+    expect(output.cy).toBe(200)
+    expect(output.clockwise).toBe(true)
+    expect(output.rx).toBe(50)
+    expect(output.ry).toBe(50)
+    expect(output.startAngle).toBeCloseTo(Math.PI)
+    expect(output.deltaAngle).toBeCloseTo(Math.PI)
+    expect(output.endAngle).toBeCloseTo(2 * Math.PI)
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,6 +3387,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
+"@types/uuid@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
+  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
+
 "@types/warning@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
@@ -10153,6 +10158,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
* Fix truncation issue in Firefox (don't give a mask ID that doesn't exist if no mask has been given);
* Fix arrowhead color never changed even for later lines with different colors;
* Provide experimental support for arcs in `Line` and `Edge`: 
```
const stage = new Stage();
stage.add(new Line({
    points: [{x: 100, y: 100}, {x: 200, y:200}], 
    curve: {curveType: 'arc', xradius: 10, yradius:20}
}))
stage.render(svg, document);
```
* Provide experimental `ImageBox` class: 
```
const stage = new Stage();
stage.add(new ImageBox({
    coords: {x: 100, y: 100}, 
    width: 200,
    height: 200,
    url: 'https://cs0320.github.io/img/planet.png'
}))
stage.render(svg, document);
```