### PR TITLE
Fix offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .DS_Store
 .code-workspace
+~
 
 # testing
 coverage

--- a/packages/d3-packages/Grid.ts
+++ b/packages/d3-packages/Grid.ts
@@ -55,6 +55,7 @@ export class Grid extends VisualObject{
             }
         }
         
+        // Cells is indexed by rows first, which are y-coordinates
         this.cells = new Array(this.config.grid_dimensions.y_size).fill([])
         for(var row = 0; row<this.cells.length;row++) { 
             this.cells[row] = new Array(this.config.grid_dimensions.x_size) 
@@ -114,7 +115,8 @@ export class Grid extends VisualObject{
         if(!ignore_warning){this.check_bounding_box(add_object.boundingBox())}
         this.children.push(add_object) 
         add_object.center = this.center_helper(coords, add_object.origin_offset) 
-        this.cells[coords.x][coords.y] = add_object // provide easy indexing for children
+        // Cells are indexed by rows first, which are y-coordinates
+        this.cells[coords.y][coords.x] = add_object // provide easy indexing for children
     }
 
     private center_helper(coords: Coords, offset: () => Coords): (() => Coords) {        

--- a/packages/d3-packages/Grid.ts
+++ b/packages/d3-packages/Grid.ts
@@ -29,7 +29,7 @@ export class Grid extends VisualObject{
      */
     private coords: () => Coords // For easier math
     config: gridProps
-    cells: Array<Array<VisualObject>>
+    private cells: Array<Array<VisualObject>>
     gridlines: Array<Line>
 
     constructor(props: gridProps){ // renamed to props for consistency
@@ -55,7 +55,10 @@ export class Grid extends VisualObject{
             }
         }
         
-        this.cells = []
+        this.cells = new Array(this.config.grid_dimensions.x_size).fill([])
+        for(var row = 0; row<this.cells.length;row++) { 
+            this.cells[row] = new Array(this.config.grid_dimensions.y_size) 
+        }
         this.gridlines = []
         this.fill_grid_lines()
     }
@@ -88,6 +91,13 @@ export class Grid extends VisualObject{
         }
     }
 
+    /**
+     * Add a child object, positioned in the appropriate row/column of this grid. 
+     * 
+     * @param coords the row and column indexes to place this object in
+     * @param add_object the object to add as a child of this grid
+     * @param ignore_warning set true to ignore insufficient-space warnings
+     */
     add(coords: Coords, add_object:VisualObject, ignore_warning?:boolean){
         /**
          * Given valid coordinates of our grid, we add and center an object to a given
@@ -102,15 +112,15 @@ export class Grid extends VisualObject{
         this.check_coords(coords)
 
         if(!ignore_warning){this.check_bounding_box(add_object.boundingBox())}
-        
-        this.children.push(add_object)
-        add_object.center = this.center_helper(coords, add_object.center) //center object
+        this.children.push(add_object)        
+        add_object.center = this.center_helper(coords, add_object.origin_offset) 
+        this.cells[coords.x][coords.y] = add_object // provide easy indexing for children
     }
 
-    private center_helper(coords: Coords, offset: () => Coords): (() => Coords) {
+    private center_helper(coords: Coords, offset: () => Coords): (() => Coords) {        
         return () => { 
-            let off: Coords = offset()
-            return {
+            let off: Coords = offset()                        
+            return {            
             x: this.coords().x + this.config.cell_size.x_size * (coords.x + .5) + off.x,
             y: this.coords().y + this.config.cell_size.y_size * (coords.y + .5) + off.y
         }}
@@ -207,5 +217,17 @@ export class Grid extends VisualObject{
             throw `coordinates out of bounds. Grid is of x_size ${this.config.grid_dimensions.x_size} and y_size ${this.config.grid_dimensions.y_size}\n
             Note: passing in 2 refers to index 2 which is the third element of the grid`
         }
+    }
+
+    /**
+     * Convenience accessor to get child at a given row,col index, if one exists
+     * @param x row index
+     * @param y column index
+     * @returns child at that index if one exists, undefined otherwise 
+     */
+    childAt(x: number, y: number): VisualObject | undefined {
+        if(this.cells[x] === undefined) return undefined
+        if(this.cells[x][y] === undefined) return undefined
+        return this.cells[x][y]
     }
 }

--- a/packages/d3-packages/Grid.ts
+++ b/packages/d3-packages/Grid.ts
@@ -55,9 +55,9 @@ export class Grid extends VisualObject{
             }
         }
         
-        this.cells = new Array(this.config.grid_dimensions.x_size).fill([])
+        this.cells = new Array(this.config.grid_dimensions.y_size).fill([])
         for(var row = 0; row<this.cells.length;row++) { 
-            this.cells[row] = new Array(this.config.grid_dimensions.y_size) 
+            this.cells[row] = new Array(this.config.grid_dimensions.x_size) 
         }
         this.gridlines = []
         this.fill_grid_lines()
@@ -112,7 +112,7 @@ export class Grid extends VisualObject{
         this.check_coords(coords)
 
         if(!ignore_warning){this.check_bounding_box(add_object.boundingBox())}
-        this.children.push(add_object)        
+        this.children.push(add_object) 
         add_object.center = this.center_helper(coords, add_object.origin_offset) 
         this.cells[coords.x][coords.y] = add_object // provide easy indexing for children
     }

--- a/packages/d3-packages/Rectangle.ts
+++ b/packages/d3-packages/Rectangle.ts
@@ -6,7 +6,7 @@ export interface RectangleProps extends ShapeProps {
   height: number | (() => number);
   width: number | (() => number);
   // Deprecated
-  //coords?: Coords | (() => Coords);
+  coords?: Coords | (() => Coords);
   labelLocation?: string;
 }
 
@@ -31,15 +31,26 @@ export class Rectangle extends Shape {
     super(props);
     this.height = toFunc(0, props.height);
     this.width = toFunc(0, props.width);
-    // Shape uses props.center; props.coords is deprecated
-    let coordsFunc = toFunc({ x: 0, y: 0 }, props.center);
     this.labelLocation = props.labelLocation ?? 'center';
-    this.center = () => {
-      return {
-        x: coordsFunc().x + this.width() / 2,
-        y: coordsFunc().y + this.height() / 2
-      };
-    };
+    const defaultCoord = {x:0, y:0}
+    if(props.center && props.coords)
+    {
+      throw("you cannot include both coords and a center as the two define the same thing");
+    }
+    this.center = (() => {
+      if(props.center)
+      {
+        return toFunc(defaultCoord, props.center)
+      } 
+      else
+      {
+        const coordsFunc = toFunc(defaultCoord, props.coords);
+          return () => {return {
+            x: coordsFunc().x + this.width() / 2,
+            y: coordsFunc().y + this.height() / 2
+          }};
+      }
+    })()
     this.setLabelLocation();
   }
 

--- a/packages/d3-packages/Rectangle.ts
+++ b/packages/d3-packages/Rectangle.ts
@@ -5,7 +5,8 @@ import { BoundingBox, Coords, toFunc } from './Utility';
 export interface RectangleProps extends ShapeProps {
   height: number | (() => number);
   width: number | (() => number);
-  coords?: Coords | (() => Coords);
+  // Deprecated
+  //coords?: Coords | (() => Coords);
   labelLocation?: string;
 }
 
@@ -18,7 +19,7 @@ export class Rectangle extends Shape {
    * Creates a logical rectangle object
    * @param height height (y direction)
    * @param width width (x direction)
-   * @param coords coordinates of the top-left point
+   * @param center coordinates of the center of the shape
    * @param color color for interior
    * @param borderWidth width of border
    * @param borderColor color of border
@@ -30,7 +31,8 @@ export class Rectangle extends Shape {
     super(props);
     this.height = toFunc(0, props.height);
     this.width = toFunc(0, props.width);
-    let coordsFunc = toFunc({ x: 0, y: 0 }, props.coords);
+    // Shape uses props.center; props.coords is deprecated
+    let coordsFunc = toFunc({ x: 0, y: 0 }, props.center);
     this.labelLocation = props.labelLocation ?? 'center';
     this.center = () => {
       return {

--- a/packages/d3-packages/ScriptViewImports.ts
+++ b/packages/d3-packages/ScriptViewImports.ts
@@ -14,6 +14,8 @@ import { Hull } from './Hull';
 import { ConjoinedObject } from './ConjoinedObject'
 import { Ellipse } from './Ellipse';
 import { ImageBox } from './ImageBox';
+import { AlloySet } from '../sterling/src/components/ScriptView/alloy-proxy/AlloySet';
+import { AlloyAtom } from '../sterling/src/components/ScriptView/alloy-proxy/AlloyAtom';
 
 interface scriptViewImport {
   name: string;
@@ -43,7 +45,10 @@ const scriptViewImports: scriptViewImport[] = [
   { name: 'ConjoinedObject', value: ConjoinedObject },
   { name: 'boxUnion', value: boxUnion },
   { name: 'Ellipse', value: Ellipse},
-  { name: 'ImageBox', value: ImageBox}
+  { name: 'ImageBox', value: ImageBox},
+  // For debugging and workaround purposes, expose some constructors 
+  { name: 'AlloySet', value: AlloySet},
+  { name: 'AlloyAtom', value: AlloyAtom}
 ];
 
 export { scriptViewImports };

--- a/packages/d3-packages/Shape.ts
+++ b/packages/d3-packages/Shape.ts
@@ -43,9 +43,9 @@ export class Shape extends VisualObject {
 
     // Disallow a `coords` field in props, because this is a common error;
     //   Shapes take `center` instead.    
-    if('coords' in props) {
-      throw Error("Shape constructor was given a 'coords' field; use 'center' instead.")
-    }
+    // if('coords' in props) {
+    //   throw Error("Shape constructor was given a 'coords' field; use 'center' instead.")
+    // }
 
     this.color = toFunc(DEFAULT_BORDER_COLOR, props.color);
     this.borderWidth = toFunc(DEFAULT_STROKE_WIDTH, props.borderWidth);

--- a/packages/d3-packages/Shape.ts
+++ b/packages/d3-packages/Shape.ts
@@ -37,19 +37,16 @@ export class Shape extends VisualObject {
    * Constructs a generic shape object. This is a top-level class,
    * which should not be used except as super class for other specific
    * shapes.
-   * @param coords coordinates of the shape
-   * @param color color of shape's interior
-   * @param borderWidth width of Shape's border
-   * @param borderColor color of border
-   * @param label text to display atop the shape
-   * @param labelColor color of text
-   * @param labelSize size of text
-   * @param style
    */
-  constructor(
-    props: ShapeProps
-  ) {
+  constructor(props: ShapeProps) {
     super(props.center);
+
+    // Disallow a `coords` field in props, because this is a common error;
+    //   Shapes take `center` instead.    
+    if('coords' in props) {
+      throw Error("Shape constructor was given a 'coords' field; use 'center' instead.")
+    }
+
     this.color = toFunc(DEFAULT_BORDER_COLOR, props.color);
     this.borderWidth = toFunc(DEFAULT_STROKE_WIDTH, props.borderWidth);
     this.borderColor = toFunc(DEFAULT_COLOR, props.borderColor);

--- a/packages/d3-packages/Tree.ts
+++ b/packages/d3-packages/Tree.ts
@@ -52,9 +52,10 @@ export class Tree extends VisualObject{
         // to be defined in terms of the center for use within the system, however, as that's
         // What's going to be edited to move the grid. 
         this.coords = () => {
-            return {
-                x: this.center().x - this.width / 2,
-                y: this.center().y - this.height / 2
+            const ctr = this.center()
+            return {                
+                x: ctr.x - this.width / 2,
+                y: ctr.y - this.height / 2
             }
         }
 
@@ -63,9 +64,12 @@ export class Tree extends VisualObject{
         this.root = props.root;
         
         let oldCenterFunc: () => Coords = this.root.visualObject.center
-        this.root.visualObject.setCenter(() => { return {
-            x: this.coords().x + this.width / 2 + oldCenterFunc().x,
-            y: this.coords().y + oldCenterFunc().y
+        this.root.visualObject.setCenter(() => { 
+            const cs = this.coords() 
+            const octr = oldCenterFunc()
+            return {
+                x: cs.x + this.width / 2 + octr.x,
+                y: cs.y + octr.y
         }})
 
         this.lines = []

--- a/packages/d3-packages/Tree.ts
+++ b/packages/d3-packages/Tree.ts
@@ -93,6 +93,7 @@ export class Tree extends VisualObject{
             let prevWidth: number = currTotalWidth
             currTotalWidth += childWidth
 
+            console.log(`subtree: ${this.coords().x + (prevWidth / totalWidth) * this.width} ${this.coords().y + layerHeight}`)
             return new Tree({
                 root: childTree, 
                 height: layerHeight * (treeHeight(childTree) - 1),

--- a/packages/d3-packages/Utility.ts
+++ b/packages/d3-packages/Utility.ts
@@ -4,12 +4,13 @@
  */
 
 export function toFunc<T>(defaultValue: T, t?: T | (() => T)): (() => T)  {
+    //console.log(`toFunc: t=${JSON.stringify(t)} ??=${JSON.stringify(t ?? defaultValue)}`)
     let constOrFunction: T | (() => T) = t ?? defaultValue
     // This will require a typecast below:
     //if (typeof constOrFunction !== "function") {
     // This does not:
     if(!(constOrFunction instanceof Function)) {
-        let constVal: T = constOrFunction
+        let constVal: T = constOrFunction      
         return () => constVal
     } else {
         // Note that this sort of narrowing will NOT work in the case of T 

--- a/packages/d3-packages/VisualObject.ts
+++ b/packages/d3-packages/VisualObject.ts
@@ -46,7 +46,7 @@ export class VisualObject {
    */
   constructor(coords?: Coords | (() => Coords)) {
     this.center = toFunc({ x: 0, y: 0 }, coords);
-    this.origin_offset = toFunc({ x: 0, y: 0 }, coords);
+    this.origin_offset = toFunc({ x: 0, y: 0 }, coords);    
     this.bounding_box_lam = (r: number) => { return this.center() };
     this.hasBoundingBox = false;
     this.children = [];

--- a/packages/d3-packages/d3lib-demonstrations/MaskedEdgedPolygon.js
+++ b/packages/d3-packages/d3lib-demonstrations/MaskedEdgedPolygon.js
@@ -1,1 +1,0 @@
-const stage = new stage()

--- a/packages/d3-packages/d3lib-demonstrations/Masks+Edges.js
+++ b/packages/d3-packages/d3lib-demonstrations/Masks+Edges.js
@@ -3,7 +3,7 @@
 
 const stage = new Stage()
 
-const r1 = new Rectangle({height: 50, width: 50, coords: {x:50,y:40}, color: "pink"})
+const r1 = new Rectangle({height: 50, width: 50, center: {x:50,y:40}, color: "pink"})
 const c1 = new Circle({radius: 45, center: {x:200, y:200}, color: "green"})
 const e = new Edge({obj1: r1, obj2: c1})
 

--- a/packages/d3-packages/d3lib-demonstrations/center-test.js
+++ b/packages/d3-packages/d3lib-demonstrations/center-test.js
@@ -1,0 +1,40 @@
+const gridRectProps = {
+    grid_location :{
+        x:0,
+        y:0
+    },
+    cell_size:{
+        x_size:25,
+        y_size:25
+    },
+    grid_dimensions:{
+        y_size:10,
+        x_size:10
+    }
+}
+const referenceGrid = new Grid(gridRectProps)
+
+/*
+both of the below rectangles should have their
+centers at (100,100)
+
+although we verify this with the testing functionality
+it is hoped that one would verify this result visually:
+The expected visual is two rectangles layered on each other
+*/
+const centerOriented = new Rectangle({height: 100, width: 100, 
+                center: {x: 100, y: 100}});
+const topLeftOriented = new Rectangle({height: 100, width: 100,
+                coords: {x:50, y:50}})
+
+centerOriented.sterlingExpectCenter("center oriented rect", 100, 100)
+topLeftOriented.sterlingExpectCenter("top left oriented rect", 100, 100)
+ 
+
+const s = new Stage()
+s.add(referenceGrid)
+s.add(centerOriented)
+s.add(topLeftOriented)
+s.render(svg)
+
+

--- a/packages/d3-packages/d3lib-demonstrations/conflictingmasksexample.js
+++ b/packages/d3-packages/d3lib-demonstrations/conflictingmasksexample.js
@@ -9,7 +9,7 @@ const stage = new Stage()
 
 
 
-const rect1 = new Rectangle({coords: {x: 50, y:50}, width: 400, height: 400})
+const rect1 = new Rectangle({center: {x: 50, y:50}, width: 400, height: 400})
 
 
 
@@ -18,12 +18,11 @@ rect1.addMask({top_left: {x:0,y:0}, bottom_right: {x:100,y:100}})
 rect1.addMask({top_left: {x:150,y:150}, bottom_right: {x:300, y:300}})
 
 
-const rect2 = new Rectangle({coords: {x:50, y:500}, width: 400, height:400})
+const rect2 = new Rectangle({center: {x:50, y:500}, width: 400, height:400})
 rect2.addMask({top_left: {x:0, y:0}, bottom_right: {x:300,y:300}})
 //proof that masks don't overlap!
 
-
-rect2.addMask({top_left: {x:75,y:505}, bottom_right: {x:100,y:700}})
+rect2.addMask({top_left: {x:75,y:200}, bottom_right: {x:100,y:700}})
 
 
 

--- a/packages/d3-packages/d3lib-demonstrations/edgeswitharrows.js
+++ b/packages/d3-packages/d3lib-demonstrations/edgeswitharrows.js
@@ -1,7 +1,7 @@
 const stage = new Stage()
 
 
-const rect = new Rectangle({width: 50, height: 50, coords: {x:200, y:50}})
+const rect = new Rectangle({width: 50, height: 50, center: {x:200, y:50}})
 const circ1 = new Circle({radius: 25, center: {x:100, y:300}})
 const circ2 = new Circle({radius: 25, center: {x:350, y:300}})
 

--- a/packages/d3-packages/d3lib-demonstrations/gridtest.js
+++ b/packages/d3-packages/d3lib-demonstrations/gridtest.js
@@ -3,6 +3,9 @@
   The intended output is a 3x3 grid with squares in its corner cells, and a 3x3 grid in its inside cell
     The inner grid has the same pattern, with an even smaller 3x3 grid in its inner cell
       The innermost grid has tiny rectangles in all 9 cells. 
+
+  To check offsetting, the middle left grid cell should contain an offset rectangle, slightly to the 
+  right and down from the cell's center. The offset rectangle will be blue and taller than it is wide.
 */
 
 
@@ -36,6 +39,16 @@ for(let i = 0; i < 3; i++){
       }
     }
 }
+
+const offsetRect = new Rectangle({height: 50, width: 30, coords:{x:50,y:25}, color:'blue'});
+// starts out with only its own parameters: 30/2 + 50 = 65; 50/2 + 25 = 50
+offsetRect.sterlingExpectCenter("offsetRect", 65, 50) 
+bigGrid.add({x:0,y:1}, offsetRect)
+// After being added to the grid, we expect the offset to be preserved
+// y: one cell down (150) + cell center (75) + offset (25)
+// x: first cell (0) + cell center (75) + offset (50)
+offsetRect.sterlingExpectCenter("offsetRect", 125, 250) 
+// ...but it was 75
 
 ///////////////////////////////////////////////////////////
 

--- a/packages/d3-packages/d3lib-demonstrations/gridtest.js
+++ b/packages/d3-packages/d3lib-demonstrations/gridtest.js
@@ -56,7 +56,7 @@ const smallGridConfig = {
 const smallGrid = new Grid(smallGridConfig)
 // This sub-grid will automatically have a center() value of {x:0,y:0}; if 
 // that isn't the case, raise an alarm while running this test. (45*3 = 135; 135 / 2 = 67.5)
-//smallGrid.sterlingExpectCenter("smallGrid on creation", 67.5, 67.5)
+smallGrid.sterlingExpectCenter("smallGrid on creation", 67.5, 67.5)
 for(let i = 0; i < 3; i++){
     for(let j =0; j<3; j++){
       if(i != 1 & j!= 1){

--- a/packages/d3-packages/d3lib-demonstrations/gridtest.js
+++ b/packages/d3-packages/d3lib-demonstrations/gridtest.js
@@ -40,7 +40,7 @@ for(let i = 0; i < 3; i++){
     }
 }
 
-const offsetRect = new Rectangle({height: 50, width: 30, coords:{x:50,y:25}, color:'blue'});
+const offsetRect = new Rectangle({height: 50, width: 30, center:{x:50,y:25}, color:'blue'});
 // starts out with only its own parameters: 30/2 + 50 = 65; 50/2 + 25 = 50
 offsetRect.sterlingExpectCenter("offsetRect", 65, 50) 
 bigGrid.add({x:0,y:1}, offsetRect)

--- a/packages/d3-packages/d3lib-demonstrations/gridtest.js
+++ b/packages/d3-packages/d3lib-demonstrations/gridtest.js
@@ -1,5 +1,14 @@
-const stage = new Stage()
+/*
+  Test script for grids and nesting grids
+  The intended output is a 3x3 grid with squares in its corner cells, and a 3x3 grid in its inside cell
+    The inner grid has the same pattern, with an even smaller 3x3 grid in its inner cell
+      The innermost grid has tiny rectangles in all 9 cells. 
+*/
 
+
+///////////////////////////////////////////////////////////
+const stage = new Stage()
+///////////////////////////////////////////////////////////
 
 const bigGridConfig = {
     grid_location :{
@@ -15,17 +24,20 @@ const bigGridConfig = {
         x_size:3
     }
 }
-
 const bigGrid = new Grid(bigGridConfig)
-
 for(let i = 0; i < 3; i++){
     for(let j =0; j<3; j++){
       if(j != 1 & i != 1){
         const newRect = new Rectangle({height: 140, width: 140});
+        // This rectangle will automatically have a center() value of {x:70,y:70}; if 
+        // that isn't the case, raise an alarm while running this test.
+        newRect.sterlingExpectCenter("upper-left rectangle on creation", 70, 70)
         bigGrid.add({x:i,y:j}, newRect)
       }
     }
 }
+
+///////////////////////////////////////////////////////////
 
 const smallGridConfig = {
     grid_location :{
@@ -42,16 +54,19 @@ const smallGridConfig = {
     }
 }
 const smallGrid = new Grid(smallGridConfig)
+// This sub-grid will automatically have a center() value of {x:0,y:0}; if 
+// that isn't the case, raise an alarm while running this test. (45*3 = 135; 135 / 2 = 67.5)
+//smallGrid.sterlingExpectCenter("smallGrid on creation", 67.5, 67.5)
 for(let i = 0; i < 3; i++){
     for(let j =0; j<3; j++){
       if(i != 1 & j!= 1){
         const newRect = new Rectangle({height: 40,width: 40});
         smallGrid.add({x:i,y:j}, newRect)
-      }
-        
+      }        
     }
 }
 
+///////////////////////////////////////////////////////////
 
 const smallerGridConfig = {
     grid_location :{
@@ -67,7 +82,6 @@ const smallerGridConfig = {
         x_size:3
     }
 }
-
 const smallerGrid = new Grid(smallerGridConfig)
 for(let i = 0; i < 3; i++){
     for(let j =0; j<3; j++){
@@ -76,12 +90,23 @@ for(let i = 0; i < 3; i++){
     }
 }
 
+///////////////////////////////////////////////////////////
+
 smallGrid.add({x:1,y:1},smallerGrid)
-
 bigGrid.add({x:1,y:1}, smallGrid)
-
 stage.add(bigGrid)
 
 stage.render(svg)
 
+///////////////////////////////////////////////////////////
 
+/* 
+  Testing <path> elements isn't always straightforward, so do some 
+  internal-consistency checking within the objects themselves.
+*/
+
+// Property: the extent of a child visual object is always contained within the parent.
+//  (This is technically checked by Grid.add() already.)
+// Instead, we can be more specific for this particular test script. We know where everything should go.
+bigGrid.cells[0][0].sterlingExpectCenter("bigGrid 0,0", 75, 75) // half of cell size: 150/2
+bigGrid.cells[2][2].sterlingExpectCenter("bigGrid 2,2", 375, 375) // half of cell size: 150/2, plus two full cells 

--- a/packages/d3-packages/d3lib-demonstrations/subductionVis.js
+++ b/packages/d3-packages/d3lib-demonstrations/subductionVis.js
@@ -156,7 +156,7 @@ attachments.concat(generalLinks).concat(specialLinks).forEach((link) => {
 
 topBox = boxUnion(["sM1", "sM5", "sM3"].map(id => objectMap[id].boundingBox()))
 topRect = new Rectangle({
-    coords: {
+    center: {
         x: topBox.top_left.x - 20,
         y: topBox.top_left.y - 20
         },

--- a/packages/d3-packages/d3lib-demonstrations/subductionVisOverhaul.js
+++ b/packages/d3-packages/d3lib-demonstrations/subductionVisOverhaul.js
@@ -185,7 +185,7 @@ topBox = boxUnion(
   ['sM1', 'sM5', 'sM3'].map((id) => objectMap[id].boundingBox())
 );
 topRect = new Rectangle({
-  coords: {
+  center: {
     x: topBox.top_left.x - BOUNDBOXPADDING,
     y: topBox.top_left.y - BOUNDBOXPADDING
   },
@@ -203,7 +203,7 @@ bottomBox = boxUnion(
   ['gM0', 'gM1', 'gM2', 'gM3', 'gM4'].map((id) => objectMap[id].boundingBox())
 );
 bottomRect = new Rectangle({
-  coords: {
+  center: {
     x: bottomBox.top_left.x - BOUNDBOXPADDING,
     y: bottomBox.top_left.y - BOUNDBOXPADDING
   },

--- a/packages/d3-packages/test/IntegrationElementaryShapes.test.ts
+++ b/packages/d3-packages/test/IntegrationElementaryShapes.test.ts
@@ -34,7 +34,7 @@ describe('Rendering Elementary Shapes', () => {
 
     const exp_x = 150, exp_y = 200, exp_h = 123, exp_w = 4213;
     const r1: Rectangle = new Rectangle( { width: exp_w, height: exp_h, 
-                                        center: {x: exp_x, y : exp_y} } )
+                                        coords: {x: exp_x, y : exp_y} } )
     stage.add(r1)
     stage.render(svg)
 

--- a/packages/d3-packages/test/IntegrationElementaryShapes.test.ts
+++ b/packages/d3-packages/test/IntegrationElementaryShapes.test.ts
@@ -34,7 +34,7 @@ describe('Rendering Elementary Shapes', () => {
 
     const exp_x = 150, exp_y = 200, exp_h = 123, exp_w = 4213;
     const r1: Rectangle = new Rectangle( { width: exp_w, height: exp_h, 
-                                        coords: {x: exp_x, y : exp_y} } )
+                                        center: {x: exp_x, y : exp_y} } )
     stage.add(r1)
     stage.render(svg)
 

--- a/packages/d3-packages/test/IntegrationRandomTest.test.ts
+++ b/packages/d3-packages/test/IntegrationRandomTest.test.ts
@@ -32,10 +32,46 @@ describe('Random tests for rendering shapes', () => {
     }
     const produceRectangleFromCharacteristics = (chars: Record<string,number>) =>
     { 
-      return new Rectangle({width: chars.width, height: chars.height, center: {x: chars.x, y: chars.y}});
+      return new Rectangle({width: chars.width, height: chars.height, coords: {x: chars.x, y: chars.y}});
     }
     FuzzTestFactory('rect', produceRectangleFromCharacteristics, produceRandomRectangleCharacteristics)
   })
+
+  it('Can render many random rectangles that are created by center', () => {
+    const min_rand = 0, max_rand = 200;
+    const produceRandomRectangleCharacteristics = () => 
+    { 
+      return {
+        x: getRandomInt(min_rand, max_rand),
+        y: getRandomInt(min_rand, max_rand),
+        height: getRandomInt(min_rand, max_rand),
+        width: getRandomInt(min_rand, max_rand)
+      }
+    }
+    const produceRectangleFromCharacteristics = (chars: Record<string,number>) =>
+    { 
+      return new Rectangle({width: chars.width, height: chars.height, center: {x: chars.x, y: chars.y}});
+    }
+
+    /* 
+     * As the dom will give us the coords for a rectangle by top left, we need to convert the expected
+     * center (and to avoid floating point issues we use a epsilon value)
+     */
+    const eps = 0.0001
+    const checkEquality = (obj: Element, characteristics: Record<string, Object>) => {
+      const topLeftX = parseFloat(obj.getAttribute("x") ?? "0") 
+      const topLeftY = parseFloat(obj.getAttribute("y") ?? "0") 
+      const height = parseFloat(obj.getAttribute("height") ?? "1")
+      const width = parseFloat(obj.getAttribute("width") ?? "1")
+      const observedCenterX = topLeftX + width/2
+      const observedCenterY = topLeftY + height/2
+      const xDiff = Math.abs(observedCenterX - parseFloat(characteristics.x.toString()))
+      const yDiff = Math.abs(observedCenterY - parseFloat(characteristics.y.toString()))
+      return xDiff <= eps && yDiff <= eps 
+      
+    }
+    FuzzTestFactory('rect', produceRectangleFromCharacteristics, produceRandomRectangleCharacteristics, checkEquality)
+  }),
   it('Can render many random circles', () => {
     const min_rand = 0, max_rand = 200;
     const produceRandomCircleCharacteristics = () => 

--- a/packages/d3-packages/test/IntegrationRandomTest.test.ts
+++ b/packages/d3-packages/test/IntegrationRandomTest.test.ts
@@ -32,7 +32,7 @@ describe('Random tests for rendering shapes', () => {
     }
     const produceRectangleFromCharacteristics = (chars: Record<string,number>) =>
     { 
-      return new Rectangle({width: chars.width, height: chars.height, coords: {x: chars.x, y: chars.y}});
+      return new Rectangle({width: chars.width, height: chars.height, center: {x: chars.x, y: chars.y}});
     }
     FuzzTestFactory('rect', produceRectangleFromCharacteristics, produceRandomRectangleCharacteristics)
   })

--- a/packages/d3-packages/test/IntegrationRerender.test.ts
+++ b/packages/d3-packages/test/IntegrationRerender.test.ts
@@ -23,8 +23,8 @@ describe('Verify re-rendering related functionality', () => {
 
     const removedX = 30, removedY = 35, removedH = 40, removedW = 60;
     const persistentX = 20, persistentY = 25, persistentH = 30, persistentW = 50;
-    const removeRect = new Rectangle({width: removedW, height: removedH, center: {x:removedX, y:removedY}})
-    const persistRect = new Rectangle({width: persistentW, height: persistentH, center: {x:persistentX, y:persistentY}})
+    const removeRect = new Rectangle({width: removedW, height: removedH, coords: {x:removedX, y:removedY}})
+    const persistRect = new Rectangle({width: persistentW, height: persistentH, coords: {x:persistentX, y:persistentY}})
     stage.add(removeRect)
     stage.add(persistRect)
     stage.render(svg)
@@ -48,7 +48,7 @@ describe('Verify re-rendering related functionality', () => {
     let svg = CreateMockSVG()
 
     const oldX = 10, oldY = 10, oldHeight = 10, oldWidth = 10;
-    const testRect = new Rectangle({width: oldWidth, height: oldHeight, center: {x:oldX, y:oldY}})
+    const testRect = new Rectangle({width: oldWidth, height: oldHeight, coords: {x:oldX, y:oldY}})
     stage.add(testRect)
     const newWidth = 40, newHeight = 40
     testRect.setWidth(newWidth)

--- a/packages/d3-packages/test/IntegrationRerender.test.ts
+++ b/packages/d3-packages/test/IntegrationRerender.test.ts
@@ -7,7 +7,7 @@ describe('Verify re-rendering related functionality', () => {
     const stage:Stage = new Stage()
     let svg = CreateMockSVG()
 
-    const testRect = new Rectangle({width: 10, height: 10, coords: {x:10, y:10}})
+    const testRect = new Rectangle({width: 10, height: 10, center: {x:10, y:10}})
     stage.add(testRect)
     stage.render(svg)
 
@@ -23,8 +23,8 @@ describe('Verify re-rendering related functionality', () => {
 
     const removedX = 30, removedY = 35, removedH = 40, removedW = 60;
     const persistentX = 20, persistentY = 25, persistentH = 30, persistentW = 50;
-    const removeRect = new Rectangle({width: removedW, height: removedH, coords: {x:removedX, y:removedY}})
-    const persistRect = new Rectangle({width: persistentW, height: persistentH, coords: {x:persistentX, y:persistentY}})
+    const removeRect = new Rectangle({width: removedW, height: removedH, center: {x:removedX, y:removedY}})
+    const persistRect = new Rectangle({width: persistentW, height: persistentH, center: {x:persistentX, y:persistentY}})
     stage.add(removeRect)
     stage.add(persistRect)
     stage.render(svg)
@@ -48,7 +48,7 @@ describe('Verify re-rendering related functionality', () => {
     let svg = CreateMockSVG()
 
     const oldX = 10, oldY = 10, oldHeight = 10, oldWidth = 10;
-    const testRect = new Rectangle({width: oldWidth, height: oldHeight, coords: {x:oldX, y:oldY}})
+    const testRect = new Rectangle({width: oldWidth, height: oldHeight, center: {x:oldX, y:oldY}})
     stage.add(testRect)
     const newWidth = 40, newHeight = 40
     testRect.setWidth(newWidth)

--- a/packages/sterling/src/components/ScriptView/alloy-proxy/AlloySignature.ts
+++ b/packages/sterling/src/components/ScriptView/alloy-proxy/AlloySignature.ts
@@ -64,6 +64,18 @@ class AlloySignature extends AlloySet {
     }
 
     /**
+     * Get an array of all tuples in this sig. This will always 
+     * include all tuples in sub-sigs as well; this is contrary 
+     * to how .atoms() works by default (accepting a parameter, with default 
+     * _not_ including sub-sigs) because .tuples() is used internally, e.g.,
+     * for .join(), which needs this behavior to preserve Alloy semantics.
+     */
+    tuples (): AlloyTuple[] {
+        return this.atoms(true).map(a => new AlloyTuple([a]))
+    }
+
+
+    /**
      * Create a clone of this signature.
      * @param proxy If provided, a proxied clone will be returned.
      */


### PR DESCRIPTION
Offsets should not use the center() of the child, because some shapes will internally change that. E.g., Rectangle changes its `center()` to be its center (offset by the `coords` given in props), **not** the original `coords`.

* This PR adds a method to `VisualObject` so that the original `coords` are accessible, and that is now used when positioning children in Grid. 
* It also adds some convenience functionality to `Grid` and the beginnings of a test case in `gridtest.js` (SVG paths are troublesome to parse, and JSDOM doesn't seem to support them fully, so checking center values unit-test style in the script.)
* Finally, passing a `coords` field to `Shape` is deprecated and will produce an error; `Shape` used (and has been using) `center` when calling the `VisualObject` constructor. 

I'm uncertain whether any other objects need changing similarly. 
Note that some examples (especially in CSCI 1710) still need updating to the props-based constructor format, but that's unrelated to this PR. 
