### PR TITLE
Origin/fix offsets

### DIFF
--- a/packages/d3-packages/Rectangle.ts
+++ b/packages/d3-packages/Rectangle.ts
@@ -6,7 +6,7 @@ export interface RectangleProps extends ShapeProps {
   height: number | (() => number);
   width: number | (() => number);
   // Deprecated
-  //coords?: Coords | (() => Coords);
+  coords?: Coords | (() => Coords);
   labelLocation?: string;
 }
 
@@ -31,15 +31,26 @@ export class Rectangle extends Shape {
     super(props);
     this.height = toFunc(0, props.height);
     this.width = toFunc(0, props.width);
-    // Shape uses props.center; props.coords is deprecated
-    let coordsFunc = toFunc({ x: 0, y: 0 }, props.center);
     this.labelLocation = props.labelLocation ?? 'center';
-    this.center = () => {
-      return {
-        x: coordsFunc().x + this.width() / 2,
-        y: coordsFunc().y + this.height() / 2
-      };
-    };
+    const defaultCoord = {x:0, y:0}
+    if(props.center && props.coords)
+    {
+      throw("you cannot include both coords and a center as the two define the same thing");
+    }
+    this.center = (() => {
+      if(props.center)
+      {
+        return toFunc(defaultCoord, props.center)
+      } 
+      else
+      {
+        const coordsFunc = toFunc(defaultCoord, props.coords);
+          return () => {return {
+            x: coordsFunc().x + this.width() / 2,
+            y: coordsFunc().y + this.height() / 2
+          }};
+      }
+    })()
     this.setLabelLocation();
   }
 

--- a/packages/d3-packages/Shape.ts
+++ b/packages/d3-packages/Shape.ts
@@ -43,9 +43,9 @@ export class Shape extends VisualObject {
 
     // Disallow a `coords` field in props, because this is a common error;
     //   Shapes take `center` instead.    
-    if('coords' in props) {
-      throw Error("Shape constructor was given a 'coords' field; use 'center' instead.")
-    }
+    // if('coords' in props) {
+    //   throw Error("Shape constructor was given a 'coords' field; use 'center' instead.")
+    // }
 
     this.color = toFunc(DEFAULT_BORDER_COLOR, props.color);
     this.borderWidth = toFunc(DEFAULT_STROKE_WIDTH, props.borderWidth);

--- a/packages/d3-packages/d3lib-demonstrations/center-test.js
+++ b/packages/d3-packages/d3lib-demonstrations/center-test.js
@@ -1,0 +1,40 @@
+const gridRectProps = {
+    grid_location :{
+        x:0,
+        y:0
+    },
+    cell_size:{
+        x_size:25,
+        y_size:25
+    },
+    grid_dimensions:{
+        y_size:10,
+        x_size:10
+    }
+}
+const referenceGrid = new Grid(gridRectProps)
+
+/*
+both of the below rectangles should have their
+centers at (100,100)
+
+although we verify this with the testing functionality
+it is hoped that one would verify this result visually:
+The expected visual is two rectangles layered on each other
+*/
+const centerOriented = new Rectangle({height: 100, width: 100, 
+                center: {x: 100, y: 100}});
+const topLeftOriented = new Rectangle({height: 100, width: 100,
+                coords: {x:50, y:50}})
+
+centerOriented.sterlingExpectCenter("center oriented rect", 100, 100)
+topLeftOriented.sterlingExpectCenter("top left oriented rect", 100, 100)
+ 
+
+const s = new Stage()
+s.add(referenceGrid)
+s.add(centerOriented)
+s.add(topLeftOriented)
+s.render(svg)
+
+

--- a/packages/d3-packages/test/IntegrationElementaryShapes.test.ts
+++ b/packages/d3-packages/test/IntegrationElementaryShapes.test.ts
@@ -34,7 +34,7 @@ describe('Rendering Elementary Shapes', () => {
 
     const exp_x = 150, exp_y = 200, exp_h = 123, exp_w = 4213;
     const r1: Rectangle = new Rectangle( { width: exp_w, height: exp_h, 
-                                        center: {x: exp_x, y : exp_y} } )
+                                        coords: {x: exp_x, y : exp_y} } )
     stage.add(r1)
     stage.render(svg)
 

--- a/packages/d3-packages/test/IntegrationRandomTest.test.ts
+++ b/packages/d3-packages/test/IntegrationRandomTest.test.ts
@@ -36,6 +36,42 @@ describe('Random tests for rendering shapes', () => {
     }
     FuzzTestFactory('rect', produceRectangleFromCharacteristics, produceRandomRectangleCharacteristics)
   })
+
+  it('Can render many random rectangles that are created by center', () => {
+    const min_rand = 0, max_rand = 200;
+    const produceRandomRectangleCharacteristics = () => 
+    { 
+      return {
+        x: getRandomInt(min_rand, max_rand),
+        y: getRandomInt(min_rand, max_rand),
+        height: getRandomInt(min_rand, max_rand),
+        width: getRandomInt(min_rand, max_rand)
+      }
+    }
+    const produceRectangleFromCharacteristics = (chars: Record<string,number>) =>
+    { 
+      return new Rectangle({width: chars.width, height: chars.height, center: {x: chars.x, y: chars.y}});
+    }
+
+    /* 
+     * As the dom will give us the coords for a rectangle by top left, we need to convert the expected
+     * center (and to avoid floating point issues we use a epsilon value)
+     */
+    const eps = 0.0001
+    const checkEquality = (obj: Element, characteristics: Record<string, Object>) => {
+      const topLeftX = parseFloat(obj.getAttribute("x") ?? "0") 
+      const topLeftY = parseFloat(obj.getAttribute("y") ?? "0") 
+      const height = parseFloat(obj.getAttribute("height") ?? "1")
+      const width = parseFloat(obj.getAttribute("width") ?? "1")
+      const observedCenterX = topLeftX + width/2
+      const observedCenterY = topLeftY + height/2
+      const xDiff = Math.abs(observedCenterX - parseFloat(characteristics.x.toString()))
+      const yDiff = Math.abs(observedCenterY - parseFloat(characteristics.y.toString()))
+      return xDiff <= eps && yDiff <= eps 
+      
+    }
+    FuzzTestFactory('rect', produceRectangleFromCharacteristics, produceRandomRectangleCharacteristics, checkEquality)
+  }),
   it('Can render many random circles', () => {
     const min_rand = 0, max_rand = 200;
     const produceRandomCircleCharacteristics = () => 

--- a/packages/d3-packages/test/IntegrationRandomTest.test.ts
+++ b/packages/d3-packages/test/IntegrationRandomTest.test.ts
@@ -32,7 +32,7 @@ describe('Random tests for rendering shapes', () => {
     }
     const produceRectangleFromCharacteristics = (chars: Record<string,number>) =>
     { 
-      return new Rectangle({width: chars.width, height: chars.height, center: {x: chars.x, y: chars.y}});
+      return new Rectangle({width: chars.width, height: chars.height, coords: {x: chars.x, y: chars.y}});
     }
     FuzzTestFactory('rect', produceRectangleFromCharacteristics, produceRandomRectangleCharacteristics)
   })

--- a/packages/d3-packages/test/IntegrationRerender.test.ts
+++ b/packages/d3-packages/test/IntegrationRerender.test.ts
@@ -23,8 +23,8 @@ describe('Verify re-rendering related functionality', () => {
 
     const removedX = 30, removedY = 35, removedH = 40, removedW = 60;
     const persistentX = 20, persistentY = 25, persistentH = 30, persistentW = 50;
-    const removeRect = new Rectangle({width: removedW, height: removedH, center: {x:removedX, y:removedY}})
-    const persistRect = new Rectangle({width: persistentW, height: persistentH, center: {x:persistentX, y:persistentY}})
+    const removeRect = new Rectangle({width: removedW, height: removedH, coords: {x:removedX, y:removedY}})
+    const persistRect = new Rectangle({width: persistentW, height: persistentH, coords: {x:persistentX, y:persistentY}})
     stage.add(removeRect)
     stage.add(persistRect)
     stage.render(svg)
@@ -48,7 +48,7 @@ describe('Verify re-rendering related functionality', () => {
     let svg = CreateMockSVG()
 
     const oldX = 10, oldY = 10, oldHeight = 10, oldWidth = 10;
-    const testRect = new Rectangle({width: oldWidth, height: oldHeight, center: {x:oldX, y:oldY}})
+    const testRect = new Rectangle({width: oldWidth, height: oldHeight, coords: {x:oldX, y:oldY}})
     stage.add(testRect)
     const newWidth = 40, newHeight = 40
     testRect.setWidth(newWidth)


### PR DESCRIPTION
Corrected the logic of the prior PR to its true intent (before the center was slightly off). Also added back coords as an argument option. All tests passing.

IMPORTANT:
A very easy potential mod that you could do would be to change the name of the param field for rect from `coords` to something like `topLeft`. I wanted to leave this choice to you (as it is relatively important, and it doesn't require any additional logic)