### PR TITLE
Theme now contains source/target index for default graph viz

### DIFF
--- a/packages/alloy-graph/srcnew/generateGraphProps.ts
+++ b/packages/alloy-graph/srcnew/generateGraphProps.ts
@@ -17,6 +17,7 @@ import {
 import {
   EdgeStyleSpec,
   getRelationIsAttribute,
+  getRelationSTIndexes,
   NodeStyleSpec,
   SterlingTheme
 } from '@/sterling-theme';
@@ -109,8 +110,17 @@ export function generateGraphProps(
 
   const generateEdgeLabel = (edge: AlloyEdge) => {
     if (edge.tuple.atoms.length > 2) {
+      // In this case, we must apply an edge label. By default, the _middle_ atoms of the tuple 
+      // will be shown, but the theme may contain overrides for sourceIndex and targetIndex. 
+      // We have source and target here, which are correct, but that isn't enough -- consider duplicates
+      // of the same atom in the tuple. Check in the theme. Watch out: use id, not name, of the relation.
+      const [sourceIndex, targetIndex] = getRelationSTIndexes(theme, edge.relation.id, edge.tuple.atoms.length)
+      const spliced = edge.tuple.atoms.slice() 
+      spliced.splice(sourceIndex, 1)
+      spliced.splice(targetIndex-1, 1)
       return (
-        edge.relation.name + `[${edge.tuple.atoms.slice(1, -1).join(', ')}]`
+        //edge.relation.name + `[${edge.tuple.atoms.slice(1, -1).join(', ')}]`
+        edge.relation.name + `[${spliced.join(', ')}]`
       );
     }
     return edge.relation.name;

--- a/packages/alloy-graph/srcnew/generateLayout.ts
+++ b/packages/alloy-graph/srcnew/generateLayout.ts
@@ -47,6 +47,7 @@ export function generateLayout(
   });
 
   forEach(edges, (edge, edgeId) => {
+    //console.log(`layout: ${edgeId} ${edge.source} ${edge.target}`)
     graph.setEdge(edge.source, edge.target, { id: edgeId });
   });
 

--- a/packages/sterling-theme/src/defaultThemeNew.ts
+++ b/packages/sterling-theme/src/defaultThemeNew.ts
@@ -1,4 +1,5 @@
 import { SterlingTheme } from '@/sterling-theme';
+import { NodeDef } from 'graph-svg-custom/types';
 
 export function defaultThemeNew(): SterlingTheme {
   return {
@@ -32,6 +33,8 @@ export function defaultThemeNew(): SterlingTheme {
     ],
     edges: [
       {
+        asAttribute: false,
+        sourceIndex: 0,
         curve: {
           type: 'bspline'
         },

--- a/packages/sterling-theme/src/getRelationIsAttribute.ts
+++ b/packages/sterling-theme/src/getRelationIsAttribute.ts
@@ -16,3 +16,30 @@ export function getRelationIsAttribute(
       )
     : false;
 }
+
+/**
+ * If this relation is themed with a source and target index, return them.
+ */
+export function getRelationSTIndexes(
+  theme: SterlingTheme | WritableDraft<SterlingTheme> | undefined,
+  relation: string, 
+  arity: number
+): [number,number] {
+  if(arity < 2) return [0, 0]
+  if(!theme) return [0,arity-1]
+  const edges = theme.edges;
+  if(!edges) return [0,arity-1];
+  
+  const firstMatch = edges.find(
+      (spec) =>
+        // Any index override to account for
+        (spec.sourceIndex || spec.targetIndex) &&
+        spec.targets?.some(
+          (target) => target === '*' || target.relation === relation
+        )
+    )
+  if(!firstMatch) return [0, arity-1];
+  const sourceIndex = firstMatch.sourceIndex ? firstMatch.sourceIndex : 0
+  const targetIndex = firstMatch.targetIndex ? firstMatch.targetIndex : arity-1
+  return [sourceIndex, targetIndex]
+}

--- a/packages/sterling-theme/src/themenew.ts
+++ b/packages/sterling-theme/src/themenew.ts
@@ -45,6 +45,10 @@ export interface EdgeStyleSpec {
   hidden?: boolean;
   // whether to display the targets as an attribute rather than an edge
   asAttribute?: boolean;
+  // if high-arity relation, what is the tuple index for the source node?
+  sourceIndex?: number;
+  // if high-arity relation, what is the tuple index for the target node?
+  targetIndex?: number;
   // the shape of the curve
   curve?: CurveDef;
   // props

--- a/packages/sterling/src/components/AppDrawer/graph/theme/style/RelationStylePanel.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/style/RelationStylePanel.tsx
@@ -57,7 +57,7 @@ const RelationStylePanel = (props: StylesTreePanel) => {
       edgeIndexRemoved({
         datum,
         relation: id,
-        style
+        which
       })
     );
   };
@@ -155,7 +155,7 @@ const RelationStylePanel = (props: StylesTreePanel) => {
       {(
         <NumberPicker
           label='Target Index'
-          value={targetIndex ? targetIndex : 1}
+          value={targetIndex ? targetIndex : ''}
           inherited={false}
           onChange={(value) => onEdgeIndexChange('targetIndex', value ? value : 1)}
           onRemove={() => onEdgeIndexRemove('targetIndex')}

--- a/packages/sterling/src/components/AppDrawer/graph/theme/style/RelationStylePanel.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/style/RelationStylePanel.tsx
@@ -6,7 +6,9 @@ import {
   edgeLabelStyleRemoved,
   edgeLabelStyleSet,
   edgeStyleRemoved,
-  edgeStyleSet
+  edgeStyleSet,
+  edgeIndexSet,
+  edgeIndexRemoved
 } from '../../../../../state/graphs/graphsSlice';
 import {
   useSterlingDispatch,
@@ -26,8 +28,9 @@ const RelationStylePanel = (props: StylesTreePanel) => {
   const style = useSterlingSelector((state) =>
     selectRelationStyle(state, datum, id)
   );
-  const { asAttribute, curve, stroke, strokeWidth, fontSize, textColor } =
-    style;
+  
+  const { asAttribute, curve, stroke, strokeWidth, fontSize, textColor,
+          sourceIndex, targetIndex } = style;
 
   const onAsAttributeChange = (selected: boolean) => {
     dispatch(
@@ -38,6 +41,28 @@ const RelationStylePanel = (props: StylesTreePanel) => {
       })
     );
   };
+
+  const onEdgeIndexChange = (which: 'sourceIndex'|'targetIndex', value: number) => {
+    dispatch(
+      edgeIndexSet({
+        datum,
+        relation: id,
+        which: which,
+        value: value
+      })
+    ); 
+  };
+  const onEdgeIndexRemove = (which: string) => {
+    dispatch(
+      edgeIndexRemoved({
+        datum,
+        relation: id,
+        style
+      })
+    );
+  };
+
+
 
   const onCurveChange = (curve: CurveDef) => {
     dispatch(
@@ -116,6 +141,24 @@ const RelationStylePanel = (props: StylesTreePanel) => {
           label='Display as attribute'
           value={asAttribute}
           onChange={onAsAttributeChange}
+        />
+      )}
+      {(
+        <NumberPicker
+          label='Source Index'
+          value={sourceIndex ? sourceIndex : 0}
+          inherited={false}
+          onChange={(value) => onEdgeIndexChange('sourceIndex', value ? value : 0)}
+          onRemove={() => onEdgeIndexRemove('sourceIndex')}
+        />
+      )}
+      {(
+        <NumberPicker
+          label='Target Index'
+          value={targetIndex ? targetIndex : 1}
+          inherited={false}
+          onChange={(value) => onEdgeIndexChange('targetIndex', value ? value : 1)}
+          onRemove={() => onEdgeIndexRemove('targetIndex')}
         />
       )}
       {stroke && (

--- a/packages/sterling/src/components/AppDrawer/graph/theme/style/common/NumberPicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/style/common/NumberPicker.tsx
@@ -1,3 +1,4 @@
+import { NumberDecrementStepper, NumberIncrementStepper, NumberInput, NumberInputField, NumberInputStepper } from '@chakra-ui/react';
 import { CloseButton } from './CloseButton';
 import { InheritedLabel } from './InheritedLabel';
 
@@ -16,7 +17,22 @@ const NumberPicker = (props: NumberPickerProps) => {
       <div className='grow text-sm'>{label}</div>
       {inherited && <InheritedLabel />}
       {!inherited && <CloseButton onClick={onRemove} />}
-      <input
+      <NumberInput 
+        size='sm' 
+        className='w-20 text-xs' 
+        min={0}
+        max={100}
+        value={value}
+        onChange={(event) => {
+          onChange(+event);
+        }}>
+        <NumberInputField />
+          <NumberInputStepper>
+            <NumberIncrementStepper />
+            <NumberDecrementStepper />
+          </NumberInputStepper>
+      </NumberInput>
+      {/* <input
         className='w-16 text-xs h-6'
         type='number'
         min='0'
@@ -25,7 +41,7 @@ const NumberPicker = (props: NumberPickerProps) => {
         onChange={(event) => {
           onChange(+event.target.value);
         }}
-      />
+      /> */}
     </div>
   );
 };

--- a/packages/sterling/src/components/AppDrawer/graph/theme/style/common/NumberPicker.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/style/common/NumberPicker.tsx
@@ -4,7 +4,7 @@ import { InheritedLabel } from './InheritedLabel';
 
 interface NumberPickerProps {
   label: string;
-  value: number;
+  value: number | '';
   inherited: boolean;
   onChange: (value: number | undefined) => void;
   onRemove: () => void;

--- a/packages/sterling/src/state/graphs/graphs.ts
+++ b/packages/sterling/src/state/graphs/graphs.ts
@@ -50,6 +50,8 @@ type Inheritable<T> = {
 
 export interface RelationStyle {
   asAttribute?: boolean;
+  sourceIndex?: number;
+  targetIndex?: number;
   curve?: Inheritable<CurveDef>;
   stroke?: Inheritable<string>;
   strokeWidth?: Inheritable<number>;

--- a/packages/sterling/src/state/graphs/graphsSlice.ts
+++ b/packages/sterling/src/state/graphs/graphsSlice.ts
@@ -20,6 +20,8 @@ export const {
   edgeLabelStyleSet,
   edgeStyleRemoved,
   edgeStyleSet,
+  edgeIndexSet,
+  edgeIndexRemoved,
   curveRemoved,
   curveSet,
   graphSpread,

--- a/packages/sterling/src/state/selectors.ts
+++ b/packages/sterling/src/state/selectors.ts
@@ -400,10 +400,13 @@ export function selectRelationStyle(
 
     const style: RelationStyle = {};
     const relations = ['*', relationId];
-
     relations.forEach((relation) => {
       specs[relation].forEach((spec) => {
+        
         const asAttribute = get(spec, ['asAttribute']);
+        const sourceIndex = get(spec, ['sourceIndex']);
+        const targetIndex = get(spec, ['targetIndex']);
+        
         const curve = get(spec, ['curve']);
         const stroke = get(spec, ['styles', 'edge', 'stroke']);
         const strokeWidth = get(spec, ['styles', 'edge', 'strokeWidth']);
@@ -411,6 +414,8 @@ export function selectRelationStyle(
         const textColor = get(spec, ['styles', 'label', 'fill']);
 
         set(style, ['asAttribute'], asAttribute === true);
+        set(style, ['sourceIndex'], sourceIndex);
+        set(style, ['targetIndex'], targetIndex);
         if (curve) {
           set(style, ['curve', 'value'], curve);
           set(style, ['curve', 'inherited'], relation !== relationId);


### PR DESCRIPTION
This PR adds two spinner selectors to the theme drawer, both of which control the layout of the default graph visualization:
* "Source Index", which controls the tuple index for the _source_ of the arc drawn; and 
* "Target Index", which controls the tuple index for the _target_ of the arc drawn. 
Any other indexes will be printed in the arc label. 

Before this PR, there was no control over which tuple indexes were used as source/target and which as edge labels; it was always index 0 = source, index (arity-1) = target, and the middle atoms on the arc label. This was a problem in a model of weighted, directed graphs like: `sig Node {edges: set Node -> Int}`. 

These new settings will be saved in the theme file, as well. 

One caveat is that perhaps these should have gone in the "Layout" drawer, which is currently empty.