### PR TITLE
Adding CnD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # sterling-ts
 
 https://sterling-docs.vercel.app/
+
+# sterling-ts
+
+```
+yarn install
+yarn run dev:forge ## Run in dev mode for forge (dev:alloy for Alloy)
+
+
+## Now Sterling runs on localhost:8081
+
+And add the forge server port as an arg (ex. localhost:8081/?62703)
+
+```
+
+### LOADING A MOCK TRACE
+(Manual Datum -- + add manual datum in Sterling window)
+
+## Maybe we want to respect layout or something? Or change layout (Theme vs Layout is tricky)
+- RelationStylePanel.tsx
+- `alloy-graph/srcnew` + `generateGraph.ts` is the new graph layout (and this is where the theme is applied)
+
+

--- a/README.md
+++ b/README.md
@@ -2,24 +2,37 @@
 
 https://sterling-docs.vercel.app/
 
-# sterling-ts
+## How to run
 
 ```
 yarn install
-yarn run dev:forge ## Run in dev mode for forge (dev:alloy for Alloy)
+```
+and then either:
+* `yarn run dev:forge` (run in dev mode for Forge)
+* `yarn run dev:alloy` (run in dev mode for Alloy; this is needed if you use the mock provider).
 
-
-## Now Sterling runs on localhost:8081
-
-And add the forge server port as an arg (ex. localhost:8081/?62703)
+Now Sterling runs on localhost:8081. If you're running versus Forge, note the instance-provider port and append it to the URL for dev Sterling. E.g., `localhost:8081/?62703` if the provider port is `62703`. In Forge, you can use the `sterling_port` option to set the provider port to something constant, so you can avoid having to edit the Sterling URL every run.
 
 ```
 
-### LOADING A MOCK TRACE
-(Manual Datum -- + add manual datum in Sterling window)
+### How to load a mock trace directly 
 
-## Maybe we want to respect layout or something? Or change layout (Theme vs Layout is tricky)
-- RelationStylePanel.tsx
-- `alloy-graph/srcnew` + `generateGraph.ts` is the new graph layout (and this is where the theme is applied)
+Go to `Manual Datum` near the bottom of the screen and paste in Alloy-style instance XML. 
 
+### Notes on locations 
+
+- For layout/theme changes:
+  - RelationStylePanel.tsx
+  - `alloy-graph/srcnew` + `generateGraph.ts` is the new graph layout (and this is where the theme is applied)
+
+
+
+
+## How to build
+
+To build:
+* `yarn run build:forge` (use this if updating Forge) or 
+* `yarn run build:alloy`. 
+
+Building will produce many files in `dist` (there are subfolders). To update Forge, copy these into the `sterling/build` folder, after deleting everything that is already there (including subfolders).
 

--- a/packages/sterling/src/components/AppDrawer/graph/GraphDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/GraphDrawer.tsx
@@ -17,6 +17,7 @@ import {
   GraphThemeDrawer,
   GraphThemeDrawerHeader
 } from './theme/GraphThemeDrawer';
+import { GraphLayoutDrawer, GraphLayoutDrawerHeader } from './theme/GraphLayoutDrawer';
 
 const GraphDrawer = () => {
   const drawer = useSterlingSelector(selectGraphDrawer);
@@ -27,9 +28,14 @@ const GraphDrawer = () => {
       {drawer === 'theme' && <GraphThemeDrawer />}
       {drawer === 'evaluator' && <EvaluatorDrawer />}
       {drawer === 'log' && <LogDrawer />}
+      {drawer === 'layout' && <GraphLayoutDrawer />}
     </>
   );
 };
+
+// state drawer = time
+// explorer = select instance
+// theme = theme
 
 const GraphDrawerHeader = () => {
   const drawer = useSterlingSelector(selectGraphDrawer);
@@ -40,6 +46,7 @@ const GraphDrawerHeader = () => {
       {drawer === 'theme' && <GraphThemeDrawerHeader />}
       {drawer === 'evaluator' && <EvaluatorDrawerHeader />}
       {drawer === 'log' && <LogDrawerHeader />}
+      {drawer === 'layout' && <GraphLayoutDrawerHeader />}
     </>
   );
 };

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -1,10 +1,10 @@
 import { PaneTitle } from '@/sterling-ui';
-import { Button, FormControl, FormLabel, Textarea } from '@chakra-ui/react';
+import { Button, FormControl, FormLabel, Textarea, Input } from '@chakra-ui/react';
 import { useState } from 'react';
-import { Icon } from '@chakra-ui/react';
-import { RiHammerFill } from 'react-icons/ri';
 import { useSterlingSelector } from '../../../../state/hooks';
 import { selectActiveDatum } from '../../../../state/selectors';
+import { RiHammerFill } from 'react-icons/ri';
+import { Icon } from '@chakra-ui/react';
 
 const GraphLayoutDrawer = () => {
   const datum = useSterlingSelector(selectActiveDatum);
@@ -43,18 +43,34 @@ const GraphLayoutDrawer = () => {
     document.body.removeChild(form);
   };
 
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const text = event.target?.result as string;
+        setCndSpecText(text);
+      };
+      reader.readAsText(file);
+    }
+  };
+
   return (
     <div className='absolute inset-0 flex flex-col overflow-y-auto p-4'>
+      <FormControl mt={4}>
+        <FormLabel>Upload layout specification file</FormLabel>
+        <Input type="file" accept=".cnd" onChange={handleFileUpload} />
+      </FormControl>
       <FormControl>
-        <FormLabel>CnD Layout Specification</FormLabel>
+        <FormLabel>Layout Specification</FormLabel>
         <Textarea
           minH="20rem"
           value={cndSpecText}
           onChange={e => setCndSpecText(e.target.value)}
         />
       </FormControl>
-      <Button onClick={openInCnd} colorScheme='blue' mt={4}>
-        Load in CnD
+      <Button onClick={openInCnd} mt={4}>
+        Load layout
       </Button>
     </div>
   );

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -1,36 +1,64 @@
 import { PaneTitle } from '@/sterling-ui';
-import { Button, FormControl, FormLabel, Icon, Textarea, VisuallyHidden, VisuallyHiddenInput } from '@chakra-ui/react';
+import { Button, FormControl, FormLabel, Textarea } from '@chakra-ui/react';
 import { useState } from 'react';
-import { RiHammerFill, RiPaletteLine } from 'react-icons/ri';
 import { useSterlingSelector } from '../../../../state/hooks';
 import { selectActiveDatum } from '../../../../state/selectors';
-import { ProjectionSection } from './projection/ProjectionSection';
-import { StyleSection } from './style/StyleSection';
-import { ThemeFileSection } from './ThemeFileSection';
 
 const GraphLayoutDrawer = () => {
   const datum = useSterlingSelector(selectActiveDatum);
 
-  const [cndSpectext, setCndSpecText] = useState<string>("")
+  const [cndSpecText, setCndSpecText] = useState<string>("");
 
   if (!datum) return null;
+
+  const openInCnd = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    // Create a form element
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = 'http://localhost:3000';
+    form.target = '_blank';
+
+    // Create input elements for the form data
+    const cndSpecTextInput = document.createElement('input');
+    cndSpecTextInput.type = 'hidden';
+    cndSpecTextInput.name = 'cope';
+    cndSpecTextInput.value = cndSpecText;
+    form.appendChild(cndSpecTextInput);
+
+    const alloyDatumInput = document.createElement('input');
+    alloyDatumInput.type = 'hidden';
+    alloyDatumInput.name = 'alloyDatum';
+    alloyDatumInput.value = datum.data;
+    form.appendChild(alloyDatumInput);
+
+    // Append the form to the body and submit it
+    document.body.appendChild(form);
+    form.submit();
+
+    // Remove the form from the document
+    document.body.removeChild(form);
+  };
+
   return (
-    <div className='absolute inset-0 flex flex-col overflow-y-auto'>
-      <form action='does.not.exist.com'>
-        <FormControl>
-            <VisuallyHidden>{datum.data}</VisuallyHidden>
-        </FormControl>
-        <FormControl>
-            <FormLabel>CnD Layout Specification</FormLabel>
-            <Textarea minH="20rem"
-                      value={cndSpectext}
-                      onChange={e => setCndSpecText(e.target.value)}/>
-        </FormControl>
-        <button type='submit'>Load in CnD</button>
-      </form>
+    <div className='absolute inset-0 flex flex-col overflow-y-auto p-4'>
+      <FormControl>
+        <FormLabel>CnD Layout Specification</FormLabel>
+        <Textarea
+          minH="20rem"
+          value={cndSpecText}
+          onChange={e => setCndSpecText(e.target.value)}
+        />
+      </FormControl>
+      <Button onClick={openInCnd} colorScheme='blue' mt={4}>
+        Load in CnD
+      </Button>
     </div>
   );
 };
+
+export default GraphLayoutDrawer;
 
 const GraphLayoutDrawerHeader = () => {
   return (
@@ -41,4 +69,4 @@ const GraphLayoutDrawerHeader = () => {
   );
 };
 
-export { GraphLayoutDrawer, GraphLayoutDrawerHeader };
+export er, GraphLayoutDrawerHeader };

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -1,6 +1,8 @@
 import { PaneTitle } from '@/sterling-ui';
 import { Button, FormControl, FormLabel, Textarea } from '@chakra-ui/react';
 import { useState } from 'react';
+import { Icon } from '@chakra-ui/react';
+import { RiHammerFill } from 'react-icons/ri';
 import { useSterlingSelector } from '../../../../state/hooks';
 import { selectActiveDatum } from '../../../../state/selectors';
 
@@ -29,7 +31,7 @@ const GraphLayoutDrawer = () => {
 
     const alloyDatumInput = document.createElement('input');
     alloyDatumInput.type = 'hidden';
-    alloyDatumInput.name = 'alloyDatum';
+    alloyDatumInput.name = 'alloydatum';
     alloyDatumInput.value = datum.data;
     form.appendChild(alloyDatumInput);
 
@@ -69,4 +71,4 @@ const GraphLayoutDrawerHeader = () => {
   );
 };
 
-export er, GraphLayoutDrawerHeader };
+export { GraphLayoutDrawer, GraphLayoutDrawerHeader };

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -1,0 +1,44 @@
+import { PaneTitle } from '@/sterling-ui';
+import { Button, FormControl, FormLabel, Icon, Textarea, VisuallyHidden, VisuallyHiddenInput } from '@chakra-ui/react';
+import { useState } from 'react';
+import { RiHammerFill, RiPaletteLine } from 'react-icons/ri';
+import { useSterlingSelector } from '../../../../state/hooks';
+import { selectActiveDatum } from '../../../../state/selectors';
+import { ProjectionSection } from './projection/ProjectionSection';
+import { StyleSection } from './style/StyleSection';
+import { ThemeFileSection } from './ThemeFileSection';
+
+const GraphLayoutDrawer = () => {
+  const datum = useSterlingSelector(selectActiveDatum);
+
+  const [cndSpectext, setCndSpecText] = useState<string>("")
+
+  if (!datum) return null;
+  return (
+    <div className='absolute inset-0 flex flex-col overflow-y-auto'>
+      <form action='does.not.exist.com'>
+        <FormControl>
+            <VisuallyHidden>{datum.data}</VisuallyHidden>
+        </FormControl>
+        <FormControl>
+            <FormLabel>CnD Layout Specification</FormLabel>
+            <Textarea minH="20rem"
+                      value={cndSpectext}
+                      onChange={e => setCndSpecText(e.target.value)}/>
+        </FormControl>
+        <button type='submit'>Load in CnD</button>
+      </form>
+    </div>
+  );
+};
+
+const GraphLayoutDrawerHeader = () => {
+  return (
+    <div className='w-full flex items-center px-2 space-x-2'>
+      <Icon as={RiHammerFill} />
+      <PaneTitle>Layout</PaneTitle>
+    </div>
+  );
+};
+
+export { GraphLayoutDrawer, GraphLayoutDrawerHeader };


### PR DESCRIPTION
Adding support for CnD specifications in the `Layout` drawer. 

- For now, this relies on a CnD server running on localhost:3000, and just creates a post request to it. 
- No CnD linting or syntax support in Sterling, however, it is supported on the CnD server AND the vscode extension.

