### PR TITLE
Autoload CnD specs if provided by Forge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .code-workspace
 ~
 
+.vscode
+
 # testing
 coverage
 

--- a/packages/alloy-instance/src/datum.ts
+++ b/packages/alloy-instance/src/datum.ts
@@ -4,7 +4,8 @@ import { SterlingTheme } from '@/sterling-theme';
 
 export interface VisualizerConfig {
   script?: string,
-  theme?: string
+  theme?: string,
+  cnd?: string
 }
 
 export interface AlloyDatum {

--- a/packages/alloy-instance/src/xml.ts
+++ b/packages/alloy-instance/src/xml.ts
@@ -10,17 +10,17 @@ export function parseAlloyXML(xml: string): AlloyDatum {
   // The provider may pass various visualizer-configuration information as part 
   // of the instance XML. (This is not part of the Alloy instance XML spec, but 
   // is useful.) 
-  const maybeVisualizer = document.querySelector('visualizer');
-  const maybeVizScriptText = maybeVisualizer === null ? 
-                               undefined : 
-                               parseStringAttribute(maybeVisualizer, 'script')
-  const maybeVizThemeText = maybeVisualizer === null ? 
-                               undefined  : 
-                               parseStringAttribute(maybeVisualizer, 'theme')
-  const maybeVizCnDText = maybeVisualizer === null ? 
-                               undefined  : 
-                               parseStringAttribute(maybeVisualizer, 'cnd')
-  
+  const visualizerElements = document.querySelectorAll('visualizer');
+  let maybeCnDText, maybeScriptText, maybeThemeText = undefined
+  for(const vis of visualizerElements) {
+    // The last visualizer element for a given attribute will apply.
+    const maybeScriptTextLocal = parseStringAttribute(vis, 'script')
+    const maybeThemeTextLocal = parseStringAttribute(vis, 'theme')
+    const maybeCnDTextLocal = parseStringAttribute(vis, 'cnd')
+    maybeScriptText = maybeScriptTextLocal ?? maybeScriptText
+    maybeCnDText = maybeCnDTextLocal ?? maybeCnDText
+    maybeThemeText = maybeThemeTextLocal ?? maybeThemeText
+  }
 
   return {
     instances: instances.map(instanceFromElement),
@@ -34,9 +34,9 @@ export function parseAlloyXML(xml: string): AlloyDatum {
     maxTrace: parseNumericAttribute(instances[0], 'maxtrace'),
     minTrace: parseNumericAttribute(instances[0], 'mintrace'),
     traceLength: parseNumericAttribute(instances[0], 'tracelength'),
-    visualizerConfig: {script: deEscape(maybeVizScriptText), 
-                       theme: deEscape(maybeVizThemeText),
-                       cnd: deEscape(maybeVizCnDText)}
+    visualizerConfig: {script: deEscape(maybeScriptText), 
+                       theme: deEscape(maybeThemeText),
+                       cnd: deEscape(maybeCnDText)}
   };
 }
 

--- a/packages/alloy-instance/src/xml.ts
+++ b/packages/alloy-instance/src/xml.ts
@@ -17,7 +17,11 @@ export function parseAlloyXML(xml: string): AlloyDatum {
   const maybeVizThemeText = maybeVisualizer === null ? 
                                undefined  : 
                                parseStringAttribute(maybeVisualizer, 'theme')
+  const maybeVizCnDText = maybeVisualizer === null ? 
+                               undefined  : 
+                               parseStringAttribute(maybeVisualizer, 'cnd')
   
+
   return {
     instances: instances.map(instanceFromElement),
     bitwidth: parseNumericAttribute(instances[0], 'bitwidth'),
@@ -31,7 +35,8 @@ export function parseAlloyXML(xml: string): AlloyDatum {
     minTrace: parseNumericAttribute(instances[0], 'mintrace'),
     traceLength: parseNumericAttribute(instances[0], 'tracelength'),
     visualizerConfig: {script: deEscape(maybeVizScriptText), 
-                       theme: deEscape(maybeVizThemeText)}
+                       theme: deEscape(maybeVizThemeText),
+                       cnd: deEscape(maybeVizCnDText)}
   };
 }
 

--- a/packages/graph-svg-custom/components/NodeLabel/NodeLabel.tsx
+++ b/packages/graph-svg-custom/components/NodeLabel/NodeLabel.tsx
@@ -10,7 +10,7 @@ const NodeLabel = (props: NodeLabelProps) => {
   return (
     <>
       {label.map((def, index) => {
-        console.log(`handling node: ${JSON.stringify(def)}`)
+        //console.log(`handling node: ${JSON.stringify(def)}`)
         const { offset, ...rest } = def;
         return (
           <Label key={index} x={offset?.x || 0} y={offset?.y || 0} {...rest} />

--- a/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
+++ b/packages/sterling/src/components/AppDrawer/graph/theme/GraphLayoutDrawer.tsx
@@ -1,17 +1,22 @@
 import { PaneTitle } from '@/sterling-ui';
 import { Button, FormControl, FormLabel, Textarea, Input } from '@chakra-ui/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSterlingSelector } from '../../../../state/hooks';
-import { selectActiveDatum } from '../../../../state/selectors';
+import { selectActiveDatum, selectCnDSpec } from '../../../../state/selectors';
 import { RiHammerFill } from 'react-icons/ri';
 import { Icon } from '@chakra-ui/react';
 
 const GraphLayoutDrawer = () => {
   const datum = useSterlingSelector(selectActiveDatum);
-
   const [cndSpecText, setCndSpecText] = useState<string>("");
-
+  
   if (!datum) return null;
+
+  /** Load from XML (if provided) once. */
+    const preloadedSpec = useSterlingSelector((state) => selectCnDSpec(state, datum))
+  useEffect( () => {
+    if(preloadedSpec !== '') setCndSpecText(preloadedSpec)
+  }, [])
 
   const openInCnd = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/packages/sterling/src/state/graphs/graphs.ts
+++ b/packages/sterling/src/state/graphs/graphs.ts
@@ -31,6 +31,9 @@ export interface GraphsState {
   themeByGeneratorName: Record<string, SterlingTheme>;
   timeByDatumId: Record<string, number>;
 
+  /** The CnD spec loaded, if any.  */
+  cndSpecByDatumId: Record<string, string>;
+
   // TODO: Refactor this
   hiddenByDatumId: Record<string, Record<string, string[]>>;
 }
@@ -78,7 +81,8 @@ export function newGraphsState(): GraphsState {
     matricesByDatumId: {},
     themeByGeneratorName: {},
     timeByDatumId: {},
-    hiddenByDatumId: {}
+    hiddenByDatumId: {},
+    cndSpecByDatumId: {}
   };
 }
 

--- a/packages/sterling/src/state/graphs/graphsExtraReducers.ts
+++ b/packages/sterling/src/state/graphs/graphsExtraReducers.ts
@@ -43,6 +43,9 @@ function dataReceived(
       // Choose the first index as the first instance to display
       state.timeByDatumId[datumId] = 0;
 
+      // If a CnD spec is present, load it into the state. 
+      state.cndSpecByDatumId[datumId] = alloyDatum.parsed.visualizerConfig?.cnd ?? ''
+
       // TODO: Remove during refactor
       state.hiddenByDatumId[datumId] = {};
     });

--- a/packages/sterling/src/state/graphs/graphsSelectors.ts
+++ b/packages/sterling/src/state/graphs/graphsSelectors.ts
@@ -74,6 +74,18 @@ function selectZoomMatrix(
   return state.matricesByDatumId[datum.id]?.zoomMatrix;
 }
 
+/**
+ * Select the pre-loaded CnD diagram spec, if any.
+ * If no spec is defined, the value with be the empty string.
+ */
+function selectCnDSpec(
+  state: GraphsState,
+  datum: DatumParsed<any>
+): string {
+  return state.cndSpecByDatumId[datum.id]
+}
+
+
 export default {
   selectGraphLayout,
   selectHiddenRelations,
@@ -81,5 +93,6 @@ export default {
   selectSpreadMatrix,
   selectTheme,
   selectTimeIndex,
-  selectZoomMatrix
+  selectZoomMatrix,
+  selectCnDSpec
 };

--- a/packages/sterling/src/state/selectors.ts
+++ b/packages/sterling/src/state/selectors.ts
@@ -648,3 +648,15 @@ export const selectTables = createSelector(
     return [];
   }
 );
+
+
+/**
+ * Select the pre-loaded CnD spec, if any. 
+ * NOTE WELL: this will not persist changes in the Layout window as of June 2025. 
+ */
+export function selectCnDSpec(
+  state: SterlingState,
+  datum: DatumParsed<any>
+): string {
+  return graphsSelectors.selectCnDSpec(state.graphs, datum);
+}


### PR DESCRIPTION
Forge will now send both script and CnD context with each instance, which Sterling needs to handle properly. This PR adds that functionality for, e.g., pre-populating the CnD text field.